### PR TITLE
fix: Mem leak in loadkey

### DIFF
--- a/src/tpm2-tss-engine.c
+++ b/src/tpm2-tss-engine.c
@@ -240,6 +240,7 @@ loadkey(ENGINE *e, const char *key_id, UI_METHOD *ui, void *cb_data)
 
     DBG("TPM2 Key loaded\n");
 
+    OPENSSL_free(tpm2Data);
     return pkey;
 error:
     if (tpm2Data)


### PR DESCRIPTION
This patch fixes mem leak in `loadkey()` function.

Memory(`tpm2Data`) allocated by `tpm2tss_tpm2data_readtpm`/`tpm2tss_tpm2data_read` remains not reed.